### PR TITLE
fix: update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jpg013/ratelimiter
+module github.com/jpg013/go_rate_limiter
 
 go 1.13
 


### PR DESCRIPTION
Seems that the repository changed its name recently but the module name in `go.mod` kept the same. 

This should fix #1 and #2 